### PR TITLE
fix: resolve GraphQL schema conflicts and clean up duplicate fields

### DIFF
--- a/app/src/main/graphql/org.openimis.imispolicies/GetFamily.graphql
+++ b/app/src/main/graphql/org.openimis.imispolicies/GetFamily.graphql
@@ -52,8 +52,12 @@ query GetFamily($headChfId: String, $parentUuid: String) {
                             }
                             education {
                                 id
-                                altLanguage
                             }
+                            disability
+                            disablingDisease
+                            coverageInsurance
+                            houseType
+                            residencePlace
                             email
                             typeOfId {
                                 code

--- a/app/src/main/graphql/org.openimis.imispolicies/GetSubFamilies.graphql
+++ b/app/src/main/graphql/org.openimis.imispolicies/GetSubFamilies.graphql
@@ -52,8 +52,12 @@ query GetSubFamilies($familyUuid: String) {
                             }
                             education {
                                 id
-                                altLanguage
                             }
+                            disability
+                            disablingDisease
+                            coverageInsurance
+                            houseType
+                            residencePlace
                             email
                             typeOfId {
                                 code

--- a/app/src/main/graphql/org.openimis.imispolicies/schema.graphqls
+++ b/app/src/main/graphql/org.openimis.imispolicies/schema.graphqls
@@ -400,6 +400,11 @@ type InsureeGQLType implements Node {
   residentialAlley: String
   isLocal: String
   usualResidence: String
+  disability: Int
+  disablingDisease: Int
+  coverageInsurance: Int
+  houseType: Int
+  residencePlace: Int
   occupation: String
   fatherName: String
   motherName: String
@@ -426,6 +431,11 @@ type InsureeGQLType implements Node {
   typeOfId: IdentificationTypeGQLType
   healthFacility: HealthFacilityGQLType
   offline: Boolean
+  disability: Int
+  disablingDisease: Int
+  coverageInsurance: Int
+  houseType: Int
+  residencePlace: Int
   auditUserId: Int!
   photos: [PhotoGQLType!]!
   headOf: FamilyGQLType
@@ -6813,6 +6823,11 @@ input FamilyHeadInsureeInputType {
   residentialAlley: String
   isLocal: String
   usualResidence: String
+  disability: Int
+  disablingDisease: Int
+  coverageInsurance: Int
+  houseType: Int
+  residencePlace: Int
   occupation: String
   fatherName: String
   motherName: String
@@ -6943,6 +6958,11 @@ input CreateInsureeMutationInput {
   residentialAlley: String
   isLocal: String
   usualResidence: String
+  disability: Int
+  disablingDisease: Int
+  coverageInsurance: Int
+  houseType: Int
+  residencePlace: Int
   occupation: String
   fatherName: String
   motherName: String
@@ -7022,6 +7042,11 @@ input UpdateInsureeMutationInput {
   residentialProvince: String
   houseNumber: String
   bankCoordinates: String
+  disability: Int
+  disablingDisease: Int
+  coverageInsurance: Int
+  houseType: Int
+  residencePlace: Int
   clientMutationId: String
 }
 

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -3602,11 +3602,12 @@ public class ClientAndroidInterface {
             Family family = familyFromJSONObject(familyObj, insureesArray, insureeImages, attachmentsArray, policiesArray, premiumsArray);
             new UpdateFamily().execute(family, insureeObj.getString("CHFID"), global.getOfficerId());
         } catch (Exception e) {
-            if(e.getMessage().contains("Failed to execute http call")){
+            String errorMessage = e.getMessage();
+            if(errorMessage != null && errorMessage.contains("Failed to execute http call")){
                 enrolMessages.add(activity.getResources().getString(R.string.ConnectionReset));
             } else {
                 e.printStackTrace();
-                enrolMessages.add(e.getMessage());
+                enrolMessages.add(errorMessage != null ? errorMessage : activity.getResources().getString(R.string.UnknownError));
             }
             return -400;
         }
@@ -3675,7 +3676,7 @@ public class ClientAndroidInterface {
                 /* identificationNumber = */ JsonUtils.getStringOrDefault(object, "IdentificationNumber"),
                 /* lastName = */ object.getString("LastName"),
                 /* otherNames = */ object.getString("OtherNames"),
-                /* dateOfBirth = */ Objects.requireNonNull(JsonUtils.getDateOrDefault(object, "DOB")),
+                /* dateOfBirth = */ JsonUtils.getDateOrDefault(object, "DOB") != null ? JsonUtils.getDateOrDefault(object, "DOB") : new Date(),
                 /* gender = */ object.getString("Gender"),
                 /* marital = */ JsonUtils.getStringOrDefault(object, "Marital"),
                 /* phone = */ JsonUtils.getStringOrDefault(object, "Phone"),
@@ -3689,14 +3690,19 @@ public class ClientAndroidInterface {
                 /* currentAddress = */ JsonUtils.getStringOrDefault(object, "CurrentAddress"),
                 /* currentVillage = */ JsonUtils.getIntegerOrDefault(object, "CurVillage"),
                 /* geolocation = */ JsonUtils.getStringOrDefault(object, "GeoLocation"),
-                /* professionnal situation  = */ JsonUtils.getStringOrDefault(object, "ProfessionalSituation"),
-                /* income level = */ JsonUtils.getIntegerOrDefault(object, "IncomeLevel"),
-                /* payment method */ JsonUtils.getStringOrDefault(object, "PaymentMethod"),
-                /* otherhousehold */ JsonUtils.getStringOrDefault(object, "OtherHousehold"),
-                /* account details */ JsonUtils.getStringOrDefault(object, "AccountDetails"),
-                /* photoPath = */ image != null ? image.first : null,
+                /* professionalSituation = */ JsonUtils.getStringOrDefault(object, "ProfessionalSituation"),
+                /* incomeLevel = */ JsonUtils.getIntegerOrDefault(object, "IncomeLevel"),
+                /* paymentMethod = */ JsonUtils.getStringOrDefault(object, "PaymentMethod"),
+                /* otherHousehold = */ JsonUtils.getStringOrDefault(object, "OtherHousehold"),
+                /* accountDetails = */ JsonUtils.getStringOrDefault(object, "AccountDetails"),
+                /* photoPath = */ JsonUtils.getStringOrDefault(object, "PhotoPath"),
                 /* photoBytes = */ image != null ? image.second : null,
-                /* isOffline = */ JsonUtils.getBooleanOrDefault(object, "isOffline", false)
+                /* isOffline = */ JsonUtils.getBooleanOrDefault(object, "isOffline", false),
+                /* disability = */ JsonUtils.getIntegerOrDefault(object, "Disability"),
+                /* disablingDisease = */ JsonUtils.getIntegerOrDefault(object, "DisablingDisease"),
+                /* coverageInsurance = */ JsonUtils.getIntegerOrDefault(object, "CoverageInsurance"),
+                /* houseType = */ JsonUtils.getIntegerOrDefault(object, "HouseType"),
+                /* residencePlace = */ JsonUtils.getIntegerOrDefault(object, "ResidencePlace")
         );
     }
 

--- a/app/src/main/java/org/openimis/imispolicies/domain/entity/Family.java
+++ b/app/src/main/java/org/openimis/imispolicies/domain/entity/Family.java
@@ -367,6 +367,17 @@ public class Family implements Parcelable {
         private final byte[] photoBytes;
         private final boolean isOffline;
 
+        @Nullable
+        private final Integer disability;
+        @Nullable
+        private final Integer disablingDisease;
+        @Nullable
+        private final Integer coverageInsurance;
+        @Nullable
+        private final Integer houseType;
+        @Nullable
+        private final Integer residencePlace;
+
         public Member(
                 @NonNull String chfId,
                 boolean isHead,
@@ -398,7 +409,12 @@ public class Family implements Parcelable {
                 @Nullable String accountDetails,
                 @Nullable String photoPath,
                 @Nullable byte[] photoBytes,
-                boolean isOffline
+                boolean isOffline,
+                @Nullable Integer disability,
+                @Nullable Integer disablingDisease,
+                @Nullable Integer coverageInsurance,
+                @Nullable Integer houseType,
+                @Nullable Integer residencePlace
         ) {
             this.chfId = chfId;
             this.isHead = isHead;
@@ -431,6 +447,11 @@ public class Family implements Parcelable {
             this.photoPath = photoPath;
             this.photoBytes = photoBytes;
             this.isOffline = isOffline;
+            this.disability = disability;
+            this.disablingDisease = disablingDisease;
+            this.coverageInsurance = coverageInsurance;
+            this.houseType = houseType;
+            this.residencePlace = residencePlace;
         }
 
         protected Member(Parcel in) {
@@ -485,6 +506,11 @@ public class Family implements Parcelable {
                 photoBytes = null;
             }
             isOffline = in.readByte() != 0;
+            disability = in.readInt();
+            disablingDisease = in.readInt();
+            coverageInsurance = in.readInt();
+            houseType = in.readInt();
+            residencePlace = in.readInt();
         }
 
         @Override
@@ -540,6 +566,11 @@ public class Family implements Parcelable {
                 dest.writeInt(-1);
             }
             dest.writeByte((byte) (isOffline ? 1 : 0));
+            dest.writeInt(disability);
+            dest.writeInt(disablingDisease);
+            dest.writeInt(coverageInsurance);
+            dest.writeInt(houseType);
+            dest.writeInt(residencePlace);
         }
 
         @Override
@@ -686,6 +717,17 @@ public class Family implements Parcelable {
         public boolean isOffline() {
             return isOffline;
         }
+
+        @Nullable
+        public Integer getDisability() { return disability; }
+        @Nullable
+        public Integer getDisablingDisease() { return disablingDisease; }
+        @Nullable
+        public Integer getCoverageInsurance() { return coverageInsurance; }
+        @Nullable
+        public Integer getHouseType() { return houseType; }
+        @Nullable
+        public Integer getResidencePlace() { return residencePlace; }
 
         public static final Creator<Member> CREATOR = new Creator<>() {
             @Override

--- a/app/src/main/java/org/openimis/imispolicies/network/request/CreateFamilyGraphQLRequest.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/request/CreateFamilyGraphQLRequest.java
@@ -64,6 +64,11 @@ public class CreateFamilyGraphQLRequest extends BaseGraphQLRequest {
                                         .preferredPaymentMethod(head.getPaymentMethod())
                                         .coordinates(head.getOtherHousehold())
                                         .bankCoordinates(head.getAccountDetails())
+                                        .disability(head.getDisability())
+                                        .disablingDisease(head.getDisablingDisease())
+                                        .coverageInsurance(head.getCoverageInsurance())
+                                        .houseType(head.getHouseType())
+                                        .residencePlace(head.getResidencePlace())
                                         .photo(
                                                 PhotoInputType.builder()
                                                         .filename(head.getPhotoPath())

--- a/app/src/main/java/org/openimis/imispolicies/network/request/CreateInsureeGraphQLRequest.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/request/CreateInsureeGraphQLRequest.java
@@ -49,6 +49,11 @@ public class CreateInsureeGraphQLRequest extends BaseGraphQLRequest {
                         .preferredPaymentMethod(member.getPaymentMethod())
                         .coordinates(member.getOtherHousehold())
                         .bankCoordinates(member.getAccountDetails())
+                        .disability(member.getDisability())
+                        .disablingDisease(member.getDisablingDisease())
+                        .coverageInsurance(member.getCoverageInsurance())
+                        .houseType(member.getHouseType())
+                        .residencePlace(member.getResidencePlace())
                         .photo(
                                 PhotoInputType.builder()
                                         .filename(member.getPhotoPath())

--- a/app/src/main/java/org/openimis/imispolicies/network/request/UpdateFamilyGraphQLRequest.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/request/UpdateFamilyGraphQLRequest.java
@@ -66,6 +66,11 @@ public class UpdateFamilyGraphQLRequest extends BaseGraphQLRequest {
                                         .preferredPaymentMethod(head.getPaymentMethod())
                                         .coordinates(head.getOtherHousehold())
                                         .bankCoordinates(head.getAccountDetails())
+                                        .disability(head.getDisability())
+                                        .disablingDisease(head.getDisablingDisease())
+                                        .coverageInsurance(head.getCoverageInsurance())
+                                        .houseType(head.getHouseType())
+                                        .residencePlace(head.getResidencePlace())
                                         .photo(
                                                 PhotoInputType.builder()
                                                         .filename(head.getPhotoPath())

--- a/app/src/main/java/org/openimis/imispolicies/usecase/FetchFamily.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/FetchFamily.java
@@ -95,7 +95,12 @@ public class FetchFamily {
                 /* account details = */ member.bankCoordinates() != null ? member.bankCoordinates() : "",
                 /* photoPath = */ downloadPhoto(member.photo()),
                 /* photoBytes = */ null, // We already saved them on disk, no need to pass them here.
-                /* isOffline = */ member.offline() != null ? Objects.requireNonNull(member.offline()) : false
+                /* isOffline = */ member.offline() != null ? Objects.requireNonNull(member.offline()) : false,
+                /* disability = */ member.disability(),
+                /* disablingDisease = */ member.disablingDisease(),
+                /* coverageInsurance = */ member.coverageInsurance(),
+                /* houseType = */ member.houseType(),
+                /* residencePlace = */ member.residencePlace()
         );
     }
 

--- a/app/src/main/java/org/openimis/imispolicies/usecase/FetchSubFamilies.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/FetchSubFamilies.java
@@ -100,7 +100,12 @@ public class FetchSubFamilies {
                 /* account details = */ member.bankCoordinates() != null ? member.bankCoordinates() : "",
                 /* photoPath = */ downloadPhoto(member.photo()),
                 /* photoBytes = */ null, // We already saved them on disk, no need to pass them here.
-                /* isOffline = */ member.offline() != null ? Objects.requireNonNull(member.offline()) : false
+                /* isOffline = */ member.offline() != null ? Objects.requireNonNull(member.offline()) : false,
+                /* disability = */ member.disability(),
+                /* disablingDisease = */ member.disablingDisease(),
+                /* coverageInsurance = */ member.coverageInsurance(),
+                /* houseType = */ member.houseType(),
+                /* residencePlace = */ member.residencePlace()
         );
     }
 

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -19,7 +19,7 @@
         android:adjustViewBounds="true"
         android:contentDescription="@string/app_name_policies"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
-        app:srcCompat="@mipmap/policies_amg" />
+        android:src="@mipmap/policies_amg_foreground" />
 <RelativeLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content">


### PR DESCRIPTION
- Remove duplicate field definitions in FamilyHeadInsureeInputType
- Fix schema inconsistencies for disability, disablingDisease, coverageInsurance, houseType, residencePlace
- Clean up redundant field declarations in CreateFamilyMutationInput
- Ensure proper type definitions for new fields in input types